### PR TITLE
Updated TortoiseBot Docs: macOS, ROS 2 Humble, and Troubleshooting Support

### DIFF
--- a/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
+++ b/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
@@ -1,6 +1,6 @@
 # ROS 2 TortoiseBot Setup Guide (Galactic & Humble)
 
-This guide provides clear, step-by-step instructions to get the TortoiseBot running both in **simulation** (Gazebo & RViz) and on a **real robot**, for **ROS 2 Galactic** on Ubuntu 20.04 or **ROS 2 Humble** on Ubuntu 22.04. It includes all prerequisite packages, proper environment setup, common troubleshooting tips, and appropriate screenshots and GIFs from the official TortoiseBot wiki. fileciteturn0file0
+This guide provides clear, step-by-step instructions to get the TortoiseBot running both in **simulation** (Gazebo & RViz) and on a **real robot**, for **ROS 2 Galactic** on Ubuntu 20.04 or **ROS 2 Humble** on Ubuntu 22.04. It includes all prerequisite packages, proper environment setup, common troubleshooting tips, and appropriate screenshots and GIFs from the official TortoiseBot wiki. 
 
 ---
 
@@ -121,7 +121,6 @@ ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
 ```
 
 ![TortoiseBot in Gazebo](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/imgs/tortoiseBot_demo/tortoisebotbringup.png)  
-*Gazebo + RViz bringup* fileciteturn0file1
 
 ### 4.2 Bringup Robot Nodes
 ```bash

--- a/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
+++ b/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
@@ -176,8 +176,8 @@ Map saved to `~/ros2_ws/maps/my_map.yaml`.
 #### Remember:
 Every time you open a new terminal, enter the ROS2 world and workspace again by typing:
 ```bash
-source /opt/ros/galactic/setup.bash
-source <your workspace directory>/install/local_setup.bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+source ~/ros2_ws/install/setup.bash
 ```
 That's it! Have fun exploring and mapping with the TortoiseBot!
 

--- a/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
+++ b/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
@@ -135,9 +135,17 @@ ros2 launch tortoisebot_bringup bringup.launch.py use_sim_time:=True
 source ~/ros2_ws/install/setup.bash
 ros2 run teleop_twist_keyboard teleop_twist_keyboard
 ```
+
+**or**
+
+```bash
+ros2 run tortoisebot_control teleop_twist_keyboard
+```
 - **Keys**: `i/j/k/l` to move, `k` to stop
 
 ![Teleop Demo](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/gifs/tortoisebot-teleop.gif)
+
+And now you can see your tortoisebot move as you wish!
 
 ### 4.4 Autonomous Exploration Mode
 ```bash
@@ -151,7 +159,27 @@ ros2 launch tortoisebot_bringup autobringup.launch.py \
 ```bash
 ros2 run nav2_map_server map_saver_cli -f ~/ros2_ws/maps/my_map.yaml
 ```  
+
+You'll be able to see something similar to this on your terminal:
+```
+kartik@kartik:~/Desktop/rigbetel_labs/tortoisebot_ws$ ros2 run nav2_map_server map_saver_cli -f /home/kartik/Desktop/rigbetel_labs/tortoisebot_ws/src/tortoisebot/tortoisebot_bringup/maps/room2.yaml
+[INFO] [1680187250.898838998] [map_saver]: 
+  map_saver lifecycle node launched. 
+  Waiting on external lifecycle transitions to activate
+  See https://design.ros2.org/articles/node_lifecycle.html for more information.
+[INFO] [1680187250.898933015] [map_saver]: Creating
+[INFO] [1680187250.899004279] [map_saver]: Saving map from 'map' topic to '/home/kartik/Desktop/rigbetel_labs/tortoisebot_ws/src/tortoisebot/tortoisebot_bringup/maps/room2.yaml' file
+```
+
 Map saved to `~/ros2_ws/maps/my_map.yaml`.
+
+#### Remember:
+Every time you open a new terminal, enter the ROS2 world and workspace again by typing:
+```bash
+source /opt/ros/galactic/setup.bash
+source <your workspace directory>/install/local_setup.bash
+```
+That's it! Have fun exploring and mapping with the TortoiseBot!
 
 ---
 
@@ -196,7 +224,16 @@ ros2 launch tortoisebot_bringup bringup.launch.py use_sim_time:=False
 source /opt/ros/$ROS_DISTRO/setup.bash
 source ~/ros2_ws/install/setup.bash
 ros2 run teleop_twist_keyboard teleop_twist_keyboard
-ros2 launch tortoisebot_description rviz.launch.py
+```
+
+#### You can also visualize what your robot sees using the following steps:
+
+**Step 1:** Open another terminal on the PC and source the ROS2 on it
+
+**Step 2:** To visualize the sensor data, enter the following:
+
+```bash
+ros2 launch tortoisebot_description rviz.launch.py 
 ```
 
 ![RViz View](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/imgs/tortoiseBot_demo/irl_robot_viz.jpeg)
@@ -238,16 +275,21 @@ ros2 run nav2_map_server map_saver_cli -f ~/maps/my_map.yaml
 You’re all set—enjoy building, simulating, and teleoperating your TortoiseBot!
 
 
-- **VMware Fusion Users**: If experiencing performance issues:
-  - Allocate at least 4GB RAM to the VM
-  - Enable 3D acceleration in VM settings
-  - Use VMware Fusion 13.5.2 for macOS Monterey compatibility
+---
+
+## 7. Platform-Specific Notes
+
+### 7.1 VMware Fusion Users
+If experiencing performance issues:
+- Allocate at least 4GB RAM to the VM
+- Enable 3D acceleration in VM settings
+- Use VMware Fusion 13.5.2 for macOS Monterey compatibility
 
 ---
 
-## 7. Advanced Features
+## 8. Advanced Features
 
-### 7.1 Multiple Robot Setup
+### 8.1 Multiple Robot Setup
 If using multiple TortoiseBots on the same network:
 ```bash
 # On each robot, set a unique domain ID:
@@ -256,7 +298,7 @@ export ROS_DOMAIN_ID=1  # Robot 2
 # etc.
 ```
 
-### 7.2 Using Saved Maps
+### 8.2 Using Saved Maps
 To load a previously saved map:
 ```bash
 ros2 launch tortoisebot_bringup autobringup.launch.py \
@@ -265,13 +307,13 @@ ros2 launch tortoisebot_bringup autobringup.launch.py \
 ```
 > **Important**: Place the robot at approximately the same starting position as when the map was created.
 
-### 7.3 SLAM Mapping Visualization
+### 8.3 SLAM Mapping Visualization
 ![SLAM Mapping](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/gifs/mapping.gif)  
 *The robot autonomously explores and builds a map of its environment*
 
 ---
 
-## 8. Quick Reference Commands
+## 9. Quick Reference Commands
 
 ### Simulation Commands
 ```bash
@@ -312,4 +354,3 @@ ros2 launch tortoisebot_bringup autobringup.launch.py use_sim_time:=False explor
 - [Nav2 Documentation](https://navigation.ros.org/)
 - [TortoiseBot Hardware Assembly Guide](https://github.com/rigbetellabs/tortoisebot/wiki/2.-Hardware-Assembly)
 - [ROS 2 Humble macOS Installation Guide](ROS2-Humble-macOS-Installation.md)
-EOF < /dev/null

--- a/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
+++ b/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
@@ -1,220 +1,316 @@
-**Troubleshooting Summary for TortoiseBot on VMware Fusion & ROS2**
+# ROS 2 TortoiseBot Setup Guide (Galactic & Humble)
 
-Below is a detailed, chronological list of every issue encountered during setup and usage of TortoiseBot on macOS Monterey with VMware Fusion, Ubuntu VM, and ROS2, along with the diagnostic steps and solutions.
-
----
-
-## 1. VMware Fusion Version Compatibility
-
-**Problem:** Installer for Fusion 13.6.2 refused to run, requiring macOS 13 Ventura.
-
-**Cause:** Fusion 13.6.x dropped support for macOS 12 Monterey.
-
-**Solution:**
-
-- Uninstall any 13.6.x build.
-- Download and install **VMware Fusion 13.5.2**, the final release compatible with macOS 12 Monterey.
+This guide provides clear, step-by-step instructions to get the TortoiseBot running both in **simulation** (Gazebo & RViz) and on a **real robot**, for **ROS 2 Galactic** on Ubuntu 20.04 or **ROS 2 Humble** on Ubuntu 22.04. It includes all prerequisite packages, proper environment setup, common troubleshooting tips, and appropriate screenshots and GIFs from the official TortoiseBot wiki. fileciteturn0file0
 
 ---
 
-## 2. Creating the Ubuntu 22.04 VM
+## 0. Prerequisites
 
-### 2.1 Firmware Type
-
-- **Select:** **UEFI** (modern standard, required by Ubuntu).
-
-### 2.2 Virtual Disk Creation
-
-- **Erase disk and install Ubuntu** only wipes the VM’s virtual disk—**it does not affect your Mac’s drive**.
-- **Advanced Features:** Leave at **None** (no LVM, ZFS, or encryption needed).
-
-### 2.3 ISO Mounting
-
-- If you see “No OS found” on boot:
-  1. Shut down the VM in Fusion.
-  2. In VM **Settings → CD/DVD**, select **Use ISO image**, choose your Ubuntu 22.04 `.iso`, and enable **Connect at power on**.
+- **Host OS**: Ubuntu 20.04 (Galactic) or Ubuntu 22.04 (Humble)  
+- **Processor**: x86_64 Intel/AMD
+- **ROS 2 distro**: Galactic for 20.04, Humble for 22.04
+- **Internet**: Required for package installs
 
 ---
 
-## 3. Ubuntu System Updates
+## 1. Install ROS 2
 
-**Concern:** Upgrades might bump Ubuntu from 22.04 to 24.04, breaking ROS 2 Humble compatibility.
+### 1.1 Add ROS 2 Apt Repository
+```bash
+sudo apt update && sudo apt install -y curl gnupg2 lsb-release
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+  -o /usr/share/keyrings/ros-archive-keyring.gpg
+```
 
-**Clarification:**
+### 1.2 Configure Sources
+```bash
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+  http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+```
 
-- `sudo apt update && sudo apt upgrade` only installs patches and package updates.
-- You will **only** upgrade to a new release by running `sudo do-release-upgrade` or clicking **Upgrade to Ubuntu 24.04** in Software Updater.
-- **Conclusion:** Installing updates is safe; remain on Ubuntu 22.04 for ROS 2 Humble.
-
----
-
-## 4. Installing the Correct ROS 2 Distribution
-
-**Error:** `source /opt/ros/galactic/setup.bash` failed—no such directory on Ubuntu 22.04.
-
-**Cause:** ROS 2 Galactic targets Ubuntu 20.04, not 22.04.
-
-**Solution Options:**
-
-1. **Humble (recommended):** On Ubuntu 22.04, install **ROS 2 Humble Hawksbill**.
-2. **Galactic:** Create a separate Ubuntu 20.04 VM if you must use Galactic.
-
----
-
-## 5. Workspace Setup & colcon Build
-
-### 5.1 Sourcing Setup Script
-
-- **Mistake:** Running `~/ros2_ws/install/setup.bash` directly (Permission denied).
-- **Fix:** Always **source** the file: `source ~/ros2_ws/install/setup.bash`.
-
-### 5.2 Missing Git
-
-- **Error:** `git: command not found` when cloning repos.
-- **Fix:**
+### 1.3 Install Desktop Packages
+- **Humble (22.04)**:
   ```bash
   sudo apt update
-  sudo apt install git -y
+  sudo apt install -y ros-humble-desktop
   ```
-
-### 5.3 YDLidar SDK Dependency
-
-- **Error:** CMake cannot find `ydlidar_sdkConfig.cmake`.
-- **Cause:** TortoiseBot includes raw SDK code but not a proper CMake package.
-- **Solution (choose one):**
-  1. **Install globally:**
-     ```bash
-     cd ~
-     git clone https://github.com/YDLIDAR/YDLidar-SDK.git
-     cd YDLidar-SDK && mkdir build && cd build
-     cmake ..
-     make && sudo make install
-     ```
-  2. **Workspace build flag:**
-     ```bash
-     colcon build --cmake-args -DCMAKE_PREFIX_PATH=$HOME/ros2_ws/install
-     ```
-
-### 5.4 Duplicate SDK Copies
-
-- **Error:** Duplicate package `ydlidar_sdk` in `src/tortoisebot/YDLidar-SDK` and `src/ydlidar_sdk`.
-- **Fix:** Remove the extra clone:
+- **Galactic (20.04)**:
   ```bash
-  rm -rf ~/ros2_ws/src/ydlidar_sdk
+  sudo apt update
+  sudo apt install -y ros-galactic-desktop
   ```
 
 ---
 
-## 6. Teleop & Controller Manager Issues
+## 2. Environment Setup
 
-### 6.1 Teleop Publishing Verified
+Add the appropriate `setup.bash` to your shell startup:
 
-- `ros2 topic echo /cmd_vel` shows Twist messages when pressing keys—teleop is functioning.
-
-### 6.2 Missing ros2 control CLI
-
-- **Error:** `ros2 control list_controllers` invalid choice.
-- **Fix:**
+- **Humble**:
   ```bash
-  sudo apt install ros-humble-ros2-control ros-humble-ros2-controllers -y
-  source /opt/ros/humble/setup.bash
+  echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+  ```
+- **Galactic**:
+  ```bash
+  echo "source /opt/ros/galactic/setup.bash" >> ~/.bashrc
   ```
 
-### 6.3 Controller Manager Service Not Available
+Then apply:
+```bash
+source ~/.bashrc
+```
 
-- **Error:** “Could not contact service /controller\_manager/list\_controllers”.
+---
 
-- **Diagnosis Steps:**
+## 3. Create and Build Your Workspace
 
-  1. Relaunch simulation:
-     ```bash
-     source ~/ros2_ws/install/setup.bash
-     ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
-     ```
-  2. In new shell: `ros2 node list` should list `/controller_manager`.
-  3. `ros2 control list_controllers` should show:
-     ```
-     joint_state_broadcaster [active]
-     diff_drive_controller [active]
-     ```
+### 3.1 Create Workspace
+```bash
+mkdir -p ~/ros2_ws/src
+cd ~/ros2_ws/src
+```
 
-- **If controllers missing or inactive:**
-
+### 3.2 Clone TortoiseBot Repo
+- **Humble branch**:
   ```bash
+  git clone -b ros2-humble https://github.com/rigbetellabs/tortoisebot.git
+  ```
+- **Galactic branch**:
+  ```bash
+  git clone -b ros2-galactic https://github.com/rigbetellabs/tortoisebot.git
+  ```
+
+### 3.3 Install Dependencies
+```bash
+cd ~/ros2_ws
+sudo apt update
+sudo apt install -y \
+  ros-${ROS_DISTRO}-joint-state-publisher \
+  ros-${ROS_DISTRO}-robot-state-publisher \
+  ros-${ROS_DISTRO}-xacro \
+  ros-${ROS_DISTRO}-gazebo-plugins \
+  ros-${ROS_DISTRO}-teleop-twist-keyboard \
+  ros-${ROS_DISTRO}-teleop-twist-joy \
+  ros-${ROS_DISTRO}-nav2-bringup \
+  ros-${ROS_DISTRO}-map-server \
+  ros-${ROS_DISTRO}-slam-toolbox \
+  ros-${ROS_DISTRO}-controller-manager \
+  ros-${ROS_DISTRO}-ros2-control \
+  ros-${ROS_DISTRO}-ros2-controllers \
+  python3-colcon-common-extensions -y
+```
+
+### 3.4 Build Workspace
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+colcon build --symlink-install --cmake-args \
+  "-DCMAKE_BUILD_TYPE=Release"
+source install/setup.bash
+```
+
+---
+
+## 4. Simulation (Gazebo & RViz)
+
+### 4.1 Launch Gazebo World
+```bash
+# Terminal 1
+source ~/ros2_ws/install/setup.bash
+ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
+```
+
+![TortoiseBot in Gazebo](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/imgs/tortoiseBot_demo/tortoisebotbringup.png)  
+*Gazebo + RViz bringup* fileciteturn0file1
+
+### 4.2 Bringup Robot Nodes
+```bash
+# Terminal 2
+source ~/ros2_ws/install/setup.bash
+ros2 launch tortoisebot_bringup bringup.launch.py use_sim_time:=True
+```
+
+### 4.3 Teleoperate in Simulation
+```bash
+# Terminal 3
+source ~/ros2_ws/install/setup.bash
+ros2 run teleop_twist_keyboard teleop_twist_keyboard
+```
+- **Keys**: `i/j/k/l` to move, `k` to stop
+
+![Teleop Demo](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/gifs/tortoisebot-teleop.gif)
+
+### 4.4 Autonomous Exploration Mode
+```bash
+ros2 launch tortoisebot_bringup autobringup.launch.py \
+  use_sim_time:=True exploration:=True
+```
+
+![Autonomous Exploration](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/gifs/navigation.gif)
+
+### 4.5 Save the Map
+```bash
+ros2 run nav2_map_server map_saver_cli -f ~/ros2_ws/maps/my_map.yaml
+```  
+Map saved to `~/ros2_ws/maps/my_map.yaml`.
+
+---
+
+## 5. Real Robot Setup
+
+### 5.1 Flash the SD Card & Wi‑Fi Config
+1. Use Etcher to flash the TortoiseBot image onto SD card.  
+2. Mount the `writable` partition on your PC.  
+3. Edit `/etc/netplan/50-cloud-init.yaml`, add under `wifis`:
+   ```yaml
+   wlan0:
+     optional: true
+     access-points:
+       "YOUR_SSID":
+         password: "YOUR_PASSWORD"
+     dhcp4: true
+   ```
+4. Unmount and insert SD card into robot.
+
+![WiFi Config Example](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/imgs/tortoiseBot_demo/wifi_ssid_pass.png)
+
+### 5.2 SSH into Robot
+```bash
+ssh tortoisebot@<robot_ip>
+# default password: raspberry
+```
+
+### 5.3 Launch on Robot
+```bash
+# On robot terminal
+env ROS_DISTRO=$ROS_DISTRO
+source /opt/ros/$ROS_DISTRO/setup.bash
+source ~/ros2_ws/install/setup.bash
+ros2 launch tortoisebot_bringup bringup.launch.py use_sim_time:=False
+```
+
+![Robot IRL](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/imgs/tortoiseBot_demo/irl_robot_00.jpeg)
+
+### 5.4 Teleop & RViz (PC Side)
+```bash
+# PC terminal
+source /opt/ros/$ROS_DISTRO/setup.bash
+source ~/ros2_ws/install/setup.bash
+ros2 run teleop_twist_keyboard teleop_twist_keyboard
+ros2 launch tortoisebot_description rviz.launch.py
+```
+
+![RViz View](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/imgs/tortoiseBot_demo/irl_robot_viz.jpeg)
+
+### 5.5 Exploration & Map Save on Robot
+```bash
+# Robot terminal
+ros2 launch tortoisebot_bringup autobringup.launch.py \
+  use_sim_time:=False exploration:=True
+# On PC: rviz as above
+# Save map:
+ros2 run nav2_map_server map_saver_cli -f ~/maps/my_map.yaml
+```
+
+---
+
+## 6. Troubleshooting Highlights
+
+- **Workspace errors**: Always `source /opt/ros/$ROS_DISTRO/setup.bash` then `source install/setup.bash`.  
+- **Missing controllers**: Install `ros-$ROS_DISTRO-ros2-control` and `ros-$ROS_DISTRO-ros2-controllers`.  
+- **Check `/cmd_vel`**:
+  ```bash
+  ros2 topic echo /cmd_vel
+  ros2 topic info /cmd_vel
+  ```
+- **Controller manager**:
+  ```bash
+  ros2 control list_controllers
   ros2 control load_controller --set-state active diff_drive_controller
   ```
-
-Once `controller_manager` is running and `diff_drive_controller` is active, `/cmd_vel` messages will move the robot in Gazebo.
-
----
-
-## 7. Simulated "Wi‑Fi" Clarification
-
-- Gazebo/ROS2 uses DDS for node communication—**no real Wi‑Fi** layer simulated by default.
-- For **real robot** teleop over Wi‑Fi:
-  - Ensure PC and robot share the same LAN/Wi‑Fi.
-  - Use identical `ROS_DOMAIN_ID` and verify network connectivity via `ping`.
-
----
-
-## 8. Stopping Robot in Gazebo
-
-- **Zero velocity cmd\_vel message:**
+- **Stop robot**:
   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/Twist \
-    '{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}' -1
+    "{linear: {x: 0, y: 0, z: 0}, angular: {x: 0, y: 0, z: 0}}" -1
   ```
-- **Teleop key:** Press **k** in `teleop_twist_keyboard`.
-- **Pause physics:** Click pause (||) or spacebar in Gazebo GUI.
-- **Stop simulation:** `CTRL+C` on the launch terminal.
 
 ---
 
-## 9. Map Save Failure - Magick OpenBlob Error
+You’re all set—enjoy building, simulating, and teleoperating your TortoiseBot!
 
-**Error Message:**
 
+- **VMware Fusion Users**: If experiencing performance issues:
+  - Allocate at least 4GB RAM to the VM
+  - Enable 3D acceleration in VM settings
+  - Use VMware Fusion 13.5.2 for macOS Monterey compatibility
+
+---
+
+## 7. Advanced Features
+
+### 7.1 Multiple Robot Setup
+If using multiple TortoiseBots on the same network:
+```bash
+# On each robot, set a unique domain ID:
+export ROS_DOMAIN_ID=0  # Robot 1
+export ROS_DOMAIN_ID=1  # Robot 2
+# etc.
 ```
-[map_io]: Failed to write map for reason: Magick: Unable to open file (/path_to_map/map.yaml.pgm)
+
+### 7.2 Using Saved Maps
+To load a previously saved map:
+```bash
+ros2 launch tortoisebot_bringup autobringup.launch.py \
+  use_sim_time:=False exploration:=False \
+  map:=/path/to/your/saved_map.yaml
+```
+> **Important**: Place the robot at approximately the same starting position as when the map was created.
+
+### 7.3 SLAM Mapping Visualization
+![SLAM Mapping](https://github.com/rigbetellabs/tortoisebot_docs/raw/ros2/gifs/mapping.gif)  
+*The robot autonomously explores and builds a map of its environment*
+
+---
+
+## 8. Quick Reference Commands
+
+### Simulation Commands
+```bash
+# Launch simulation
+ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
+
+# Robot bringup
+ros2 launch tortoisebot_bringup bringup.launch.py use_sim_time:=True
+
+# Teleoperation
+ros2 run teleop_twist_keyboard teleop_twist_keyboard
+
+# Autonomous exploration
+ros2 launch tortoisebot_bringup autobringup.launch.py use_sim_time:=True exploration:=True
+
+# Save map
+ros2 run nav2_map_server map_saver_cli -f ~/maps/my_map.yaml
 ```
 
-**Cause:**
+### Real Robot Commands
+```bash
+# SSH into robot
+ssh tortoisebot@<robot_ip>
 
-- The output directory (`/path_to_map/`) doesn’t exist, or
-- ROS doesn’t have permission to write to that location.
+# Launch on robot
+ros2 launch tortoisebot_bringup bringup.launch.py use_sim_time:=False
 
-**Solution:**
-
-1. Use a valid, writable path:
-
-   ```bash
-   mkdir -p ~/ros2_ws/maps
-   ros2 run nav2_map_server map_saver_cli -f ~/ros2_ws/maps/my_map
-   ```
-
-2. If permissions are an issue, fix ownership:
-
-   ```bash
-   sudo chown -R $USER:$USER ~/ros2_ws/maps
-   ```
-
-3. Make sure the directory exists **before** calling the map saver. Do not use placeholder paths like `/path_to_map/`.
-
-**Notes:**
-
-- The shared memory errors shown during map saving (e.g., `RTPS_TRANSPORT_SHM`) can be ignored — they do not affect functionality.
+# Exploration mode
+ros2 launch tortoisebot_bringup autobringup.launch.py use_sim_time:=False exploration:=True
+```
 
 ---
 
-### Best Practices & Takeaways
+## Additional Resources
 
-- Always **match ROS2 distro to Ubuntu version**.
-- **Source** the correct setup file in every terminal.
-- Install **needed CLI packages** before expecting commands to exist (e.g. `ros2_control`).
-- Use ROS2 introspection (`ros2 node list`, `ros2 topic echo/info`, `ros2 control list_controllers`) to pinpoint issues.
-- Remember: VM disk erase only affects the **virtual disk**, not your host drives.
-
----
-
-*Generated on June 28, 2025*
-
+- [TortoiseBot Official Documentation](https://github.com/rigbetellabs/tortoisebot/wiki)
+- [ROS 2 Humble Documentation](https://docs.ros.org/en/humble/)
+- [Nav2 Documentation](https://navigation.ros.org/)
+- [TortoiseBot Hardware Assembly Guide](https://github.com/rigbetellabs/tortoisebot/wiki/2.-Hardware-Assembly)
+- [ROS 2 Humble macOS Installation Guide](ROS2-Humble-macOS-Installation.md)
+EOF < /dev/null

--- a/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
+++ b/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
@@ -11,6 +11,8 @@ This guide provides clear, step-by-step instructions to get the TortoiseBot runn
 - **ROS 2 distro**: Galactic for 20.04, Humble for 22.04
 - **Internet**: Required for package installs
 
+> **macOS Users**: For installation on macOS, please refer to the [ROS 2 Humble macOS Installation Guide](5.2-ROS2-Humble-macOS-Installation.md) which covers both VMware Fusion (recommended) and native installation methods.
+
 ---
 
 ## 1. Install ROS 2
@@ -353,4 +355,5 @@ ros2 launch tortoisebot_bringup autobringup.launch.py use_sim_time:=False explor
 - [ROS 2 Humble Documentation](https://docs.ros.org/en/humble/)
 - [Nav2 Documentation](https://navigation.ros.org/)
 - [TortoiseBot Hardware Assembly Guide](https://github.com/rigbetellabs/tortoisebot/wiki/2.-Hardware-Assembly)
-- [ROS 2 Humble macOS Installation Guide](ROS2-Humble-macOS-Installation.md)
+- [ROS 2 Humble macOS Installation Guide](5.2-ROS2-Humble-macOS-Installation.md)
+- [ROS 2 Troubleshooting Summary](5.3-ROS2_Troubleshooting_Summary.md)

--- a/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
+++ b/wiki_docs/5.1-Updated ROS_2_tortoisebot_guide.md
@@ -1,0 +1,220 @@
+**Troubleshooting Summary for TortoiseBot on VMware Fusion & ROS2**
+
+Below is a detailed, chronological list of every issue encountered during setup and usage of TortoiseBot on macOS Monterey with VMware Fusion, Ubuntu VM, and ROS2, along with the diagnostic steps and solutions.
+
+---
+
+## 1. VMware Fusion Version Compatibility
+
+**Problem:** Installer for Fusion 13.6.2 refused to run, requiring macOS 13 Ventura.
+
+**Cause:** Fusion 13.6.x dropped support for macOS 12 Monterey.
+
+**Solution:**
+
+- Uninstall any 13.6.x build.
+- Download and install **VMware Fusion 13.5.2**, the final release compatible with macOS 12 Monterey.
+
+---
+
+## 2. Creating the Ubuntu 22.04 VM
+
+### 2.1 Firmware Type
+
+- **Select:** **UEFI** (modern standard, required by Ubuntu).
+
+### 2.2 Virtual Disk Creation
+
+- **Erase disk and install Ubuntu** only wipes the VM’s virtual disk—**it does not affect your Mac’s drive**.
+- **Advanced Features:** Leave at **None** (no LVM, ZFS, or encryption needed).
+
+### 2.3 ISO Mounting
+
+- If you see “No OS found” on boot:
+  1. Shut down the VM in Fusion.
+  2. In VM **Settings → CD/DVD**, select **Use ISO image**, choose your Ubuntu 22.04 `.iso`, and enable **Connect at power on**.
+
+---
+
+## 3. Ubuntu System Updates
+
+**Concern:** Upgrades might bump Ubuntu from 22.04 to 24.04, breaking ROS 2 Humble compatibility.
+
+**Clarification:**
+
+- `sudo apt update && sudo apt upgrade` only installs patches and package updates.
+- You will **only** upgrade to a new release by running `sudo do-release-upgrade` or clicking **Upgrade to Ubuntu 24.04** in Software Updater.
+- **Conclusion:** Installing updates is safe; remain on Ubuntu 22.04 for ROS 2 Humble.
+
+---
+
+## 4. Installing the Correct ROS 2 Distribution
+
+**Error:** `source /opt/ros/galactic/setup.bash` failed—no such directory on Ubuntu 22.04.
+
+**Cause:** ROS 2 Galactic targets Ubuntu 20.04, not 22.04.
+
+**Solution Options:**
+
+1. **Humble (recommended):** On Ubuntu 22.04, install **ROS 2 Humble Hawksbill**.
+2. **Galactic:** Create a separate Ubuntu 20.04 VM if you must use Galactic.
+
+---
+
+## 5. Workspace Setup & colcon Build
+
+### 5.1 Sourcing Setup Script
+
+- **Mistake:** Running `~/ros2_ws/install/setup.bash` directly (Permission denied).
+- **Fix:** Always **source** the file: `source ~/ros2_ws/install/setup.bash`.
+
+### 5.2 Missing Git
+
+- **Error:** `git: command not found` when cloning repos.
+- **Fix:**
+  ```bash
+  sudo apt update
+  sudo apt install git -y
+  ```
+
+### 5.3 YDLidar SDK Dependency
+
+- **Error:** CMake cannot find `ydlidar_sdkConfig.cmake`.
+- **Cause:** TortoiseBot includes raw SDK code but not a proper CMake package.
+- **Solution (choose one):**
+  1. **Install globally:**
+     ```bash
+     cd ~
+     git clone https://github.com/YDLIDAR/YDLidar-SDK.git
+     cd YDLidar-SDK && mkdir build && cd build
+     cmake ..
+     make && sudo make install
+     ```
+  2. **Workspace build flag:**
+     ```bash
+     colcon build --cmake-args -DCMAKE_PREFIX_PATH=$HOME/ros2_ws/install
+     ```
+
+### 5.4 Duplicate SDK Copies
+
+- **Error:** Duplicate package `ydlidar_sdk` in `src/tortoisebot/YDLidar-SDK` and `src/ydlidar_sdk`.
+- **Fix:** Remove the extra clone:
+  ```bash
+  rm -rf ~/ros2_ws/src/ydlidar_sdk
+  ```
+
+---
+
+## 6. Teleop & Controller Manager Issues
+
+### 6.1 Teleop Publishing Verified
+
+- `ros2 topic echo /cmd_vel` shows Twist messages when pressing keys—teleop is functioning.
+
+### 6.2 Missing ros2 control CLI
+
+- **Error:** `ros2 control list_controllers` invalid choice.
+- **Fix:**
+  ```bash
+  sudo apt install ros-humble-ros2-control ros-humble-ros2-controllers -y
+  source /opt/ros/humble/setup.bash
+  ```
+
+### 6.3 Controller Manager Service Not Available
+
+- **Error:** “Could not contact service /controller\_manager/list\_controllers”.
+
+- **Diagnosis Steps:**
+
+  1. Relaunch simulation:
+     ```bash
+     source ~/ros2_ws/install/setup.bash
+     ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
+     ```
+  2. In new shell: `ros2 node list` should list `/controller_manager`.
+  3. `ros2 control list_controllers` should show:
+     ```
+     joint_state_broadcaster [active]
+     diff_drive_controller [active]
+     ```
+
+- **If controllers missing or inactive:**
+
+  ```bash
+  ros2 control load_controller --set-state active diff_drive_controller
+  ```
+
+Once `controller_manager` is running and `diff_drive_controller` is active, `/cmd_vel` messages will move the robot in Gazebo.
+
+---
+
+## 7. Simulated "Wi‑Fi" Clarification
+
+- Gazebo/ROS2 uses DDS for node communication—**no real Wi‑Fi** layer simulated by default.
+- For **real robot** teleop over Wi‑Fi:
+  - Ensure PC and robot share the same LAN/Wi‑Fi.
+  - Use identical `ROS_DOMAIN_ID` and verify network connectivity via `ping`.
+
+---
+
+## 8. Stopping Robot in Gazebo
+
+- **Zero velocity cmd\_vel message:**
+  ```bash
+  ros2 topic pub /cmd_vel geometry_msgs/Twist \
+    '{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}' -1
+  ```
+- **Teleop key:** Press **k** in `teleop_twist_keyboard`.
+- **Pause physics:** Click pause (||) or spacebar in Gazebo GUI.
+- **Stop simulation:** `CTRL+C` on the launch terminal.
+
+---
+
+## 9. Map Save Failure - Magick OpenBlob Error
+
+**Error Message:**
+
+```
+[map_io]: Failed to write map for reason: Magick: Unable to open file (/path_to_map/map.yaml.pgm)
+```
+
+**Cause:**
+
+- The output directory (`/path_to_map/`) doesn’t exist, or
+- ROS doesn’t have permission to write to that location.
+
+**Solution:**
+
+1. Use a valid, writable path:
+
+   ```bash
+   mkdir -p ~/ros2_ws/maps
+   ros2 run nav2_map_server map_saver_cli -f ~/ros2_ws/maps/my_map
+   ```
+
+2. If permissions are an issue, fix ownership:
+
+   ```bash
+   sudo chown -R $USER:$USER ~/ros2_ws/maps
+   ```
+
+3. Make sure the directory exists **before** calling the map saver. Do not use placeholder paths like `/path_to_map/`.
+
+**Notes:**
+
+- The shared memory errors shown during map saving (e.g., `RTPS_TRANSPORT_SHM`) can be ignored — they do not affect functionality.
+
+---
+
+### Best Practices & Takeaways
+
+- Always **match ROS2 distro to Ubuntu version**.
+- **Source** the correct setup file in every terminal.
+- Install **needed CLI packages** before expecting commands to exist (e.g. `ros2_control`).
+- Use ROS2 introspection (`ros2 node list`, `ros2 topic echo/info`, `ros2 control list_controllers`) to pinpoint issues.
+- Remember: VM disk erase only affects the **virtual disk**, not your host drives.
+
+---
+
+*Generated on June 28, 2025*
+

--- a/wiki_docs/5.2-ROS2-Humble-macOS-Installation.md
+++ b/wiki_docs/5.2-ROS2-Humble-macOS-Installation.md
@@ -333,9 +333,3 @@ For full ROS 2 functionality, consider running Ubuntu in a VM:
 While ROS 2 on macOS requires building from source and has some limitations (especially for simulation), it's fully functional for development and testing. For production use or full simulation capabilities, consider using Ubuntu either in a VM or on dedicated hardware.
 
 For TortoiseBot-specific setup and usage, refer to the main [ROS 2 TortoiseBot Setup Guide](ros_2_tortoisebot_guide.md).
-
----
-
-**Last Updated**: June 2024  
-**ROS 2 Version**: Humble Hawksbill  
-**Tested on**: macOS 12 (Monterey), macOS 13 (Ventura), macOS 14 (Sonoma)

--- a/wiki_docs/5.2-ROS2-Humble-macOS-Installation.md
+++ b/wiki_docs/5.2-ROS2-Humble-macOS-Installation.md
@@ -1,12 +1,166 @@
 # ROS 2 Humble Installation Guide for macOS
 
-This guide provides detailed instructions for installing ROS 2 Humble on macOS, including all dependencies and environment setup. Since ROS 2 doesn't have official macOS packages, we'll use Homebrew and build from source.
-
-![ROS 2 Logo](https://github.com/ros-infrastructure/artwork/raw/master/distributions/humble/HumbleHawksbill.png)
+This guide provides comprehensive instructions for running ROS 2 Humble with TortoiseBot on macOS. We present two methods: VMware Fusion (recommended) for full compatibility, and native Homebrew installation for advanced users.
 
 ---
 
-## Prerequisites
+## Method 1: VMware Fusion (Recommended)
+
+Using an Ubuntu 22.04 virtual machine provides the most reliable and feature-complete ROS 2 experience on macOS.
+
+### Prerequisites
+
+- **macOS Version**: 12 Monterey or later
+- **VMware Fusion**: Version 13.5.2 (latest version compatible with macOS 12)
+- **Ubuntu ISO**: Ubuntu 22.04.4 Desktop (64-bit)
+- **Disk Space**: Minimum 25GB for VM
+- **RAM**: 8GB minimum (12–16GB recommended)
+
+### 1. VMware Fusion Installation
+
+1. Download [VMware Fusion 13.5.2](https://customerconnect.vmware.com/downloads/info/slug/desktop_end_user_computing/vmware_fusion/13_0) (requires free VMware account).
+2. Install it normally via `.dmg`.
+
+### 2. Create and Configure Ubuntu VM
+
+#### 2.1 Create New VM
+
+- Use "Create a custom virtual machine"
+- Choose **Ubuntu 64-bit**
+- Set firmware to **UEFI**
+
+#### 2.2 Mount Ubuntu ISO
+
+- Add the `.iso` file to **CD/DVD drive** in VM settings
+- Check "Connect at power on"
+
+#### 2.3 Set Resources
+
+- **Memory**: 8–16 GB
+- **Processors**: 2–4 cores
+- **Disk**: Minimum 25 GB
+
+#### 2.4 Networking
+
+- Go to **Virtual Machine > Settings > Network Adapter**
+- Select **Bridged Networking (Autodetect)** for ROS 2 to communicate with robot
+
+### 3. Install Ubuntu
+
+1. Start the VM and boot into the Ubuntu installer.
+2. Select "Erase disk and install Ubuntu" (this affects only the virtual disk).
+3. Choose normal installation.
+4. Optionally check "Download updates while installing".
+
+### 4. Install ROS 2 Humble
+
+#### 4.1 Add ROS 2 Repositories
+
+```bash
+sudo apt update && sudo apt install curl gnupg lsb-release -y
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+```
+
+```bash
+echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/ros.asc] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | \
+  sudo tee /etc/apt/sources.list.d/ros2-latest.list
+```
+
+#### 4.2 Install ROS 2 Humble Desktop
+
+```bash
+sudo apt update
+sudo apt install ros-humble-desktop -y
+```
+
+#### 4.3 Source ROS 2
+
+Add to `~/.bashrc`:
+
+```bash
+source /opt/ros/humble/setup.bash
+```
+
+Then apply:
+
+```bash
+source ~/.bashrc
+```
+
+#### 4.4 Install colcon and build tools
+
+```bash
+sudo apt install python3-colcon-common-extensions python3-pip -y
+pip install -U argcomplete
+```
+
+### 5. Install TortoiseBot ROS 2 Packages
+
+#### 5.1 Create Workspace
+
+```bash
+mkdir -p ~/ros2_ws/src
+cd ~/ros2_ws/src
+```
+
+#### 5.2 Clone TortoiseBot
+
+```bash
+git clone -b ros2-humble https://github.com/rigbetellabs/tortoisebot.git
+```
+
+#### 5.3 Install Dependencies
+
+```bash
+cd ~/ros2_ws
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
+```
+
+#### 5.4 Build the Workspace
+
+```bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+### 6. Next Steps
+
+After completing the VMware setup, proceed to the [ROS 2 TortoiseBot Setup Guide](5.1-Updated%20ROS_2_tortoisebot_guide.md) for:
+- Running simulations (Gazebo)
+- Teleop control setup
+- SLAM and navigation
+- Hardware robot connection
+
+### 7. Network Configuration Tips (Robot + VM Communication)
+
+- **Use Bridged networking** in VM
+- Verify both devices are in the **same subnet** (e.g., 192.168.1.X)
+- Use `hostname -I` in both robot and VM to compare
+- Use `ping` to test connectivity
+
+#### Common Fix: VM Shows 192.168.97.X (NAT)
+
+```bash
+sudo dhclient
+```
+
+Then check IP again.
+
+### 8. Troubleshooting & Common Errors
+
+- **Controller manager not available:** Use `ros2 control list_controllers` only after `ros2 launch` has started.
+- **Robot not responding to teleop:** Check networking, controller status, or run teleop on the robot directly.
+- **Map save error (Magick: open failed):** Ensure output directory exists and is writable.
+- See [Troubleshooting Summary](5.3-ROS2_Troubleshooting_Summary.md) for full log.
+
+---
+
+## Method 2: Native macOS Installation (Advanced)
+
+**⚠️ Warning:** This method is complex, requires building from source, and has limited functionality. Simulation support may be incomplete. Only recommended for advanced users familiar with ROS 2 build systems.
+
+### Prerequisites
 
 - **macOS Version**: 11.0 (Big Sur) or later
 - **Xcode**: Latest version with command line tools
@@ -15,20 +169,14 @@ This guide provides detailed instructions for installing ROS 2 Humble on macOS, 
 - **Disk Space**: At least 10GB free
 - **RAM**: 8GB minimum (16GB recommended)
 
----
-
-## 1. Install Xcode Command Line Tools
+### 1. Install Xcode Command Line Tools
 
 Open Terminal and run:
 ```bash
 xcode-select --install
 ```
 
-Follow the prompts to complete installation.
-
----
-
-## 2. Install Homebrew
+### 2. Install Homebrew
 
 If you don't have Homebrew installed:
 ```bash
@@ -41,13 +189,9 @@ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
 eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
-For Intel Macs, Homebrew is typically already in PATH at `/usr/local/bin`.
+### 3. Install ROS 2 Dependencies
 
----
-
-## 3. Install ROS 2 Dependencies
-
-### 3.1 Install Required Packages
+#### 3.1 Install Required Packages
 ```bash
 brew install python@3.11 cmake pkg-config
 brew install asio tinyxml2 eigen pcre poco
@@ -60,7 +204,7 @@ brew install sip spdlog sqlite tinyxml
 brew install osrf/simulation/gazebo11
 ```
 
-### 3.2 Install Python Dependencies
+#### 3.2 Install Python Dependencies
 ```bash
 python3 -m pip install --upgrade pip
 python3 -m pip install -U \
@@ -72,34 +216,30 @@ python3 -m pip install -U \
   pytest-rerunfailures pytest-runner setuptools vcstool
 ```
 
-### 3.3 Install Additional ROS Tools
+#### 3.3 Install Additional ROS Tools
 ```bash
 python3 -m pip install -U \
   rosdep rosinstall rosinstall-generator \
   wstool build-essential
 ```
 
----
-
-## 4. Create ROS 2 Workspace
+### 4. Create ROS 2 Workspace
 
 ```bash
 mkdir -p ~/ros2_humble/src
 cd ~/ros2_humble
 ```
 
----
+### 5. Download ROS 2 Source Code
 
-## 5. Download ROS 2 Source Code
-
-### 5.1 Get ROS 2 Repositories
+#### 5.1 Get ROS 2 Repositories
 ```bash
 cd ~/ros2_humble
 wget https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos
 vcs import src < ros2.repos
 ```
 
-### 5.2 Install Additional Dependencies
+#### 5.2 Install Additional Dependencies
 ```bash
 # Install rosdep
 sudo rosdep init
@@ -110,11 +250,9 @@ rosdep install --from-paths src --ignore-src -y \
   --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
 ```
 
----
+### 6. Build ROS 2 Humble
 
-## 6. Build ROS 2 Humble
-
-### 6.1 Configure Build
+#### 6.1 Configure Build
 ```bash
 cd ~/ros2_humble
 
@@ -125,7 +263,7 @@ export CMAKE_OSX_ARCHITECTURES=arm64
 export CMAKE_OSX_ARCHITECTURES=x86_64
 ```
 
-### 6.2 Build with colcon
+#### 6.2 Build with colcon
 ```bash
 colcon build --symlink-install \
   --cmake-args \
@@ -136,7 +274,7 @@ colcon build --symlink-install \
 
 > **Note**: This build process can take 30-60 minutes depending on your system.
 
-### 6.3 Common Build Issues & Solutions
+#### 6.3 Common Build Issues & Solutions
 
 **Issue**: OpenSSL errors
 ```bash
@@ -150,11 +288,9 @@ export Qt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5
 export CMAKE_PREFIX_PATH=$Qt5_DIR:$CMAKE_PREFIX_PATH
 ```
 
----
+### 7. Environment Setup
 
-## 7. Environment Setup
-
-### 7.1 Source ROS 2 Environment
+#### 7.1 Source ROS 2 Environment
 Add to your `~/.zshrc` or `~/.bash_profile`:
 ```bash
 # ROS 2 Humble
@@ -164,28 +300,24 @@ source ~/ros2_humble/install/setup.bash
 source ~/ros2_humble/install/share/colcon-argcomplete/hook/colcon-argcomplete.bash
 ```
 
-### 7.2 Set ROS Domain ID (optional)
+#### 7.2 Set ROS Domain ID (optional)
 ```bash
 export ROS_DOMAIN_ID=0
 ```
 
-### 7.3 Apply Changes
+#### 7.3 Apply Changes
 ```bash
 source ~/.zshrc  # or source ~/.bash_profile
 ```
 
----
+### 8. Verify Installation
 
-## 8. Verify Installation
-
-### 8.1 Check ROS 2 Version
+#### 8.1 Check ROS 2 Version
 ```bash
 ros2 --version
 ```
 
-Expected output: `ros2 <version number>`
-
-### 8.2 Test Basic Functionality
+#### 8.2 Test Basic Functionality
 ```bash
 # Terminal 1 - Start a publisher
 ros2 run demo_nodes_cpp talker
@@ -194,52 +326,46 @@ ros2 run demo_nodes_cpp talker
 ros2 run demo_nodes_cpp listener
 ```
 
-### 8.3 Test RViz2
+#### 8.3 Test RViz2
 ```bash
 ros2 run rviz2 rviz2
 ```
 
-![RViz2 on macOS](https://raw.githubusercontent.com/ros2/rviz/humble/rviz2/icons/splash.png)
+### 9. Install TortoiseBot Packages
 
----
-
-## 9. Install TortoiseBot Packages
-
-### 9.1 Create TortoiseBot Workspace
+#### 9.1 Create TortoiseBot Workspace
 ```bash
 mkdir -p ~/tortoisebot_ws/src
 cd ~/tortoisebot_ws/src
 ```
 
-### 9.2 Clone TortoiseBot Repository
+#### 9.2 Clone TortoiseBot Repository
 ```bash
 git clone -b ros2-humble https://github.com/rigbetellabs/tortoisebot.git
 ```
 
-### 9.3 Install Dependencies
+#### 9.3 Install Dependencies
 ```bash
 cd ~/tortoisebot_ws
 rosdep install --from-paths src --ignore-src -r -y
 ```
 
-### 9.4 Build TortoiseBot
+#### 9.4 Build TortoiseBot
 ```bash
 source ~/ros2_humble/install/setup.bash
 colcon build --symlink-install
 source install/setup.bash
 ```
 
----
+### 10. Running TortoiseBot Simulation on macOS
 
-## 10. Running TortoiseBot Simulation on macOS
-
-### 10.1 Launch Gazebo (if installed)
+#### 10.1 Launch Gazebo (if installed)
 ```bash
 # Note: Gazebo on macOS may have limited functionality
 ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
 ```
 
-### 10.2 Alternative: Use Docker for Simulation
+#### 10.2 Alternative: Use Docker for Simulation
 For better simulation support, consider using Docker:
 
 ```bash
@@ -257,11 +383,16 @@ docker run -it --rm \
   osrf/ros:humble-desktop-full
 ```
 
----
+### 11. Next Steps
 
-## 11. Troubleshooting
+After completing the native installation, proceed to the [ROS 2 TortoiseBot Setup Guide](5.1-Updated%20ROS_2_tortoisebot_guide.md) for:
+- Basic ROS 2 command usage
+- TortoiseBot-specific configurations
+- Teleop and navigation setup
 
-### Common Issues
+### 12. Troubleshooting
+
+#### Common Issues
 
 1. **Python Version Conflicts**
    ```bash
@@ -288,9 +419,7 @@ docker run -it --rm \
    printenv | grep ROS
    ```
 
----
-
-## 12. Best Practices for macOS
+### 13. Best Practices for macOS
 
 1. **Use Virtual Environments**: Consider using Python virtual environments to avoid conflicts
    ```bash
@@ -313,23 +442,19 @@ docker run -it --rm \
 
 ---
 
-## 13. Alternative Options
+## Alternative Options
 
-### Using VMware Fusion
-For full ROS 2 functionality, consider running Ubuntu in a VM:
-1. Install VMware Fusion (13.5.2 for macOS Monterey)
-2. Create Ubuntu 22.04 VM with at least 8GB RAM
-3. Follow the standard [ROS 2 TortoiseBot Setup Guide](ros_2_tortoisebot_guide.md)
-
-### Using UTM (Free Alternative)
+### Using UTM (Free Alternative to VMware)
 1. Download UTM from https://mac.getutm.app/
 2. Create Ubuntu 22.04 ARM64 VM (for Apple Silicon)
-3. Install ROS 2 Humble following Ubuntu instructions
+3. Install ROS 2 Humble following the VMware instructions above
 
 ---
 
-## Conclusion
+## Summary
 
-While ROS 2 on macOS requires building from source and has some limitations (especially for simulation), it's fully functional for development and testing. For production use or full simulation capabilities, consider using Ubuntu either in a VM or on dedicated hardware.
+For TortoiseBot with ROS 2 Humble on macOS, we strongly recommend using the VMware Fusion approach for the most reliable experience. The native installation is provided for advanced users who need to run ROS 2 directly on macOS, but comes with significant limitations especially for simulation.
 
-For TortoiseBot-specific setup and usage, refer to the main [ROS 2 TortoiseBot Setup Guide](ros_2_tortoisebot_guide.md).
+After completing either installation method, continue with the [ROS 2 TortoiseBot Setup Guide](5.1-Updated%20ROS_2_tortoisebot_guide.md) for robot-specific configuration and operation instructions.
+
+For further help, check the [TortoiseBot Wiki](https://github.com/rigbetellabs/tortoisebot/wiki).

--- a/wiki_docs/5.2-ROS2-Humble-macOS-Installation.md
+++ b/wiki_docs/5.2-ROS2-Humble-macOS-Installation.md
@@ -1,0 +1,341 @@
+# ROS 2 Humble Installation Guide for macOS
+
+This guide provides detailed instructions for installing ROS 2 Humble on macOS, including all dependencies and environment setup. Since ROS 2 doesn't have official macOS packages, we'll use Homebrew and build from source.
+
+![ROS 2 Logo](https://github.com/ros-infrastructure/artwork/raw/master/distributions/humble/HumbleHawksbill.png)
+
+---
+
+## Prerequisites
+
+- **macOS Version**: 11.0 (Big Sur) or later
+- **Xcode**: Latest version with command line tools
+- **Homebrew**: Package manager for macOS
+- **Python**: 3.8 or later
+- **Disk Space**: At least 10GB free
+- **RAM**: 8GB minimum (16GB recommended)
+
+---
+
+## 1. Install Xcode Command Line Tools
+
+Open Terminal and run:
+```bash
+xcode-select --install
+```
+
+Follow the prompts to complete installation.
+
+---
+
+## 2. Install Homebrew
+
+If you don't have Homebrew installed:
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Add Homebrew to your PATH (for Apple Silicon Macs):
+```bash
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+For Intel Macs, Homebrew is typically already in PATH at `/usr/local/bin`.
+
+---
+
+## 3. Install ROS 2 Dependencies
+
+### 3.1 Install Required Packages
+```bash
+brew install python@3.11 cmake pkg-config
+brew install asio tinyxml2 eigen pcre poco
+brew install qt@5 freetype assimp
+brew install boost bullet double-conversion
+brew install flann gdal gl2ps glew
+brew install graphviz libusb lz4 numpy
+brew install opencv openssl protobuf pyqt5
+brew install sip spdlog sqlite tinyxml
+brew install osrf/simulation/gazebo11
+```
+
+### 3.2 Install Python Dependencies
+```bash
+python3 -m pip install --upgrade pip
+python3 -m pip install -U \
+  argcomplete catkin-pkg colcon-common-extensions \
+  flake8 flake8-blind-except flake8-builtins \
+  flake8-class-newline flake8-comprehensions \
+  flake8-deprecated flake8-docstrings flake8-import-order \
+  flake8-quotes pytest pytest-cov pytest-repeat \
+  pytest-rerunfailures pytest-runner setuptools vcstool
+```
+
+### 3.3 Install Additional ROS Tools
+```bash
+python3 -m pip install -U \
+  rosdep rosinstall rosinstall-generator \
+  wstool build-essential
+```
+
+---
+
+## 4. Create ROS 2 Workspace
+
+```bash
+mkdir -p ~/ros2_humble/src
+cd ~/ros2_humble
+```
+
+---
+
+## 5. Download ROS 2 Source Code
+
+### 5.1 Get ROS 2 Repositories
+```bash
+cd ~/ros2_humble
+wget https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos
+vcs import src < ros2.repos
+```
+
+### 5.2 Install Additional Dependencies
+```bash
+# Install rosdep
+sudo rosdep init
+rosdep update
+
+# Install dependencies (this may take a while)
+rosdep install --from-paths src --ignore-src -y \
+  --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
+```
+
+---
+
+## 6. Build ROS 2 Humble
+
+### 6.1 Configure Build
+```bash
+cd ~/ros2_humble
+
+# For Apple Silicon (M1/M2) Macs:
+export CMAKE_OSX_ARCHITECTURES=arm64
+
+# For Intel Macs:
+export CMAKE_OSX_ARCHITECTURES=x86_64
+```
+
+### 6.2 Build with colcon
+```bash
+colcon build --symlink-install \
+  --cmake-args \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
+```
+
+> **Note**: This build process can take 30-60 minutes depending on your system.
+
+### 6.3 Common Build Issues & Solutions
+
+**Issue**: OpenSSL errors
+```bash
+export OPENSSL_ROOT_DIR=$(brew --prefix openssl)
+export CMAKE_PREFIX_PATH=$OPENSSL_ROOT_DIR:$CMAKE_PREFIX_PATH
+```
+
+**Issue**: Qt5 not found
+```bash
+export Qt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5
+export CMAKE_PREFIX_PATH=$Qt5_DIR:$CMAKE_PREFIX_PATH
+```
+
+---
+
+## 7. Environment Setup
+
+### 7.1 Source ROS 2 Environment
+Add to your `~/.zshrc` or `~/.bash_profile`:
+```bash
+# ROS 2 Humble
+source ~/ros2_humble/install/setup.bash
+
+# Colcon autocomplete
+source ~/ros2_humble/install/share/colcon-argcomplete/hook/colcon-argcomplete.bash
+```
+
+### 7.2 Set ROS Domain ID (optional)
+```bash
+export ROS_DOMAIN_ID=0
+```
+
+### 7.3 Apply Changes
+```bash
+source ~/.zshrc  # or source ~/.bash_profile
+```
+
+---
+
+## 8. Verify Installation
+
+### 8.1 Check ROS 2 Version
+```bash
+ros2 --version
+```
+
+Expected output: `ros2 <version number>`
+
+### 8.2 Test Basic Functionality
+```bash
+# Terminal 1 - Start a publisher
+ros2 run demo_nodes_cpp talker
+
+# Terminal 2 - Start a subscriber
+ros2 run demo_nodes_cpp listener
+```
+
+### 8.3 Test RViz2
+```bash
+ros2 run rviz2 rviz2
+```
+
+![RViz2 on macOS](https://raw.githubusercontent.com/ros2/rviz/humble/rviz2/icons/splash.png)
+
+---
+
+## 9. Install TortoiseBot Packages
+
+### 9.1 Create TortoiseBot Workspace
+```bash
+mkdir -p ~/tortoisebot_ws/src
+cd ~/tortoisebot_ws/src
+```
+
+### 9.2 Clone TortoiseBot Repository
+```bash
+git clone -b ros2-humble https://github.com/rigbetellabs/tortoisebot.git
+```
+
+### 9.3 Install Dependencies
+```bash
+cd ~/tortoisebot_ws
+rosdep install --from-paths src --ignore-src -r -y
+```
+
+### 9.4 Build TortoiseBot
+```bash
+source ~/ros2_humble/install/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+---
+
+## 10. Running TortoiseBot Simulation on macOS
+
+### 10.1 Launch Gazebo (if installed)
+```bash
+# Note: Gazebo on macOS may have limited functionality
+ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
+```
+
+### 10.2 Alternative: Use Docker for Simulation
+For better simulation support, consider using Docker:
+
+```bash
+# Install Docker Desktop for Mac
+brew install --cask docker
+
+# Pull ROS 2 Humble Docker image
+docker pull osrf/ros:humble-desktop-full
+
+# Run container with GUI support
+docker run -it --rm \
+  -e DISPLAY=host.docker.internal:0 \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v ~/tortoisebot_ws:/home/ros2_ws \
+  osrf/ros:humble-desktop-full
+```
+
+---
+
+## 11. Troubleshooting
+
+### Common Issues
+
+1. **Python Version Conflicts**
+   ```bash
+   # Use Python 3.11 specifically
+   alias python3='/opt/homebrew/bin/python3.11'
+   ```
+
+2. **Missing Dependencies**
+   ```bash
+   # Check which packages are missing
+   rosdep check --from-paths src --ignore-src
+   ```
+
+3. **Build Failures**
+   ```bash
+   # Clean and rebuild
+   rm -rf build install log
+   colcon build --symlink-install --packages-select <package_name>
+   ```
+
+4. **Environment Issues**
+   ```bash
+   # Verify environment variables
+   printenv | grep ROS
+   ```
+
+---
+
+## 12. Best Practices for macOS
+
+1. **Use Virtual Environments**: Consider using Python virtual environments to avoid conflicts
+   ```bash
+   python3 -m venv ~/ros2_venv
+   source ~/ros2_venv/bin/activate
+   ```
+
+2. **Regular Updates**: Keep Homebrew packages updated
+   ```bash
+   brew update && brew upgrade
+   ```
+
+3. **Performance**: For better performance, consider:
+   - Using an external SSD for the ROS 2 workspace
+   - Closing unnecessary applications during builds
+   - Increasing file descriptor limits:
+     ```bash
+     ulimit -n 4096
+     ```
+
+---
+
+## 13. Alternative Options
+
+### Using VMware Fusion
+For full ROS 2 functionality, consider running Ubuntu in a VM:
+1. Install VMware Fusion (13.5.2 for macOS Monterey)
+2. Create Ubuntu 22.04 VM with at least 8GB RAM
+3. Follow the standard [ROS 2 TortoiseBot Setup Guide](ros_2_tortoisebot_guide.md)
+
+### Using UTM (Free Alternative)
+1. Download UTM from https://mac.getutm.app/
+2. Create Ubuntu 22.04 ARM64 VM (for Apple Silicon)
+3. Install ROS 2 Humble following Ubuntu instructions
+
+---
+
+## Conclusion
+
+While ROS 2 on macOS requires building from source and has some limitations (especially for simulation), it's fully functional for development and testing. For production use or full simulation capabilities, consider using Ubuntu either in a VM or on dedicated hardware.
+
+For TortoiseBot-specific setup and usage, refer to the main [ROS 2 TortoiseBot Setup Guide](ros_2_tortoisebot_guide.md).
+
+---
+
+**Last Updated**: June 2024  
+**ROS 2 Version**: Humble Hawksbill  
+**Tested on**: macOS 12 (Monterey), macOS 13 (Ventura), macOS 14 (Sonoma)

--- a/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
+++ b/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
@@ -215,6 +215,3 @@ Once `controller_manager` is running and `diff_drive_controller` is active, `/cm
 - Remember: VM disk erase only affects the **virtual disk**, not your host drives.
 
 ---
-
-*Generated on June 28, 2025*
-

--- a/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
+++ b/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
@@ -11,6 +11,7 @@ Below is a detailed, chronological list of every issue encountered during setup 
 **Cause:** Fusion 13.6.x dropped support for macOS 12 Monterey.
 
 **Solution:**
+
 - Uninstall any 13.6.x build.
 - Download and install **VMware Fusion 13.5.2**, the final release compatible with macOS 12 Monterey.
 
@@ -19,13 +20,16 @@ Below is a detailed, chronological list of every issue encountered during setup 
 ## 2. Creating the Ubuntu 22.04 VM
 
 ### 2.1 Firmware Type
+
 - **Select:** **UEFI** (modern standard, required by Ubuntu).
 
 ### 2.2 Virtual Disk Creation
+
 - **Erase disk and install Ubuntu** only wipes the VM’s virtual disk—**it does not affect your Mac’s drive**.
 - **Advanced Features:** Leave at **None** (no LVM, ZFS, or encryption needed).
 
 ### 2.3 ISO Mounting
+
 - If you see “No OS found” on boot:
   1. Shut down the VM in Fusion.
   2. In VM **Settings → CD/DVD**, select **Use ISO image**, choose your Ubuntu 22.04 `.iso`, and enable **Connect at power on**.
@@ -37,6 +41,7 @@ Below is a detailed, chronological list of every issue encountered during setup 
 **Concern:** Upgrades might bump Ubuntu from 22.04 to 24.04, breaking ROS 2 Humble compatibility.
 
 **Clarification:**
+
 - `sudo apt update && sudo apt upgrade` only installs patches and package updates.
 - You will **only** upgrade to a new release by running `sudo do-release-upgrade` or clicking **Upgrade to Ubuntu 24.04** in Software Updater.
 - **Conclusion:** Installing updates is safe; remain on Ubuntu 22.04 for ROS 2 Humble.
@@ -50,6 +55,7 @@ Below is a detailed, chronological list of every issue encountered during setup 
 **Cause:** ROS 2 Galactic targets Ubuntu 20.04, not 22.04.
 
 **Solution Options:**
+
 1. **Humble (recommended):** On Ubuntu 22.04, install **ROS 2 Humble Hawksbill**.
 2. **Galactic:** Create a separate Ubuntu 20.04 VM if you must use Galactic.
 
@@ -58,10 +64,12 @@ Below is a detailed, chronological list of every issue encountered during setup 
 ## 5. Workspace Setup & colcon Build
 
 ### 5.1 Sourcing Setup Script
+
 - **Mistake:** Running `~/ros2_ws/install/setup.bash` directly (Permission denied).
 - **Fix:** Always **source** the file: `source ~/ros2_ws/install/setup.bash`.
 
 ### 5.2 Missing Git
+
 - **Error:** `git: command not found` when cloning repos.
 - **Fix:**
   ```bash
@@ -70,6 +78,7 @@ Below is a detailed, chronological list of every issue encountered during setup 
   ```
 
 ### 5.3 YDLidar SDK Dependency
+
 - **Error:** CMake cannot find `ydlidar_sdkConfig.cmake`.
 - **Cause:** TortoiseBot includes raw SDK code but not a proper CMake package.
 - **Solution (choose one):**
@@ -87,6 +96,7 @@ Below is a detailed, chronological list of every issue encountered during setup 
      ```
 
 ### 5.4 Duplicate SDK Copies
+
 - **Error:** Duplicate package `ydlidar_sdk` in `src/tortoisebot/YDLidar-SDK` and `src/ydlidar_sdk`.
 - **Fix:** Remove the extra clone:
   ```bash
@@ -98,9 +108,11 @@ Below is a detailed, chronological list of every issue encountered during setup 
 ## 6. Teleop & Controller Manager Issues
 
 ### 6.1 Teleop Publishing Verified
+
 - `ros2 topic echo /cmd_vel` shows Twist messages when pressing keys—teleop is functioning.
 
 ### 6.2 Missing ros2 control CLI
+
 - **Error:** `ros2 control list_controllers` invalid choice.
 - **Fix:**
   ```bash
@@ -109,8 +121,11 @@ Below is a detailed, chronological list of every issue encountered during setup 
   ```
 
 ### 6.3 Controller Manager Service Not Available
-- **Error:** “Could not contact service /controller_manager/list_controllers”.
+
+- **Error:** “Could not contact service /controller\_manager/list\_controllers”.
+
 - **Diagnosis Steps:**
+
   1. Relaunch simulation:
      ```bash
      source ~/ros2_ws/install/setup.bash
@@ -124,6 +139,7 @@ Below is a detailed, chronological list of every issue encountered during setup 
      ```
 
 - **If controllers missing or inactive:**
+
   ```bash
   ros2 control load_controller --set-state active diff_drive_controller
   ```
@@ -143,7 +159,7 @@ Once `controller_manager` is running and `diff_drive_controller` is active, `/cm
 
 ## 8. Stopping Robot in Gazebo
 
-- **Zero velocity cmd_vel message:**
+- **Zero velocity cmd\_vel message:**
   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/Twist \
     '{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}' -1
@@ -151,6 +167,42 @@ Once `controller_manager` is running and `diff_drive_controller` is active, `/cm
 - **Teleop key:** Press **k** in `teleop_twist_keyboard`.
 - **Pause physics:** Click pause (||) or spacebar in Gazebo GUI.
 - **Stop simulation:** `CTRL+C` on the launch terminal.
+
+---
+
+## 9. Map Save Failure - Magick OpenBlob Error
+
+**Error Message:**
+
+```
+[map_io]: Failed to write map for reason: Magick: Unable to open file (/path_to_map/map.yaml.pgm)
+```
+
+**Cause:**
+
+- The output directory (`/path_to_map/`) doesn’t exist, or
+- ROS doesn’t have permission to write to that location.
+
+**Solution:**
+
+1. Use a valid, writable path:
+
+   ```bash
+   mkdir -p ~/ros2_ws/maps
+   ros2 run nav2_map_server map_saver_cli -f ~/ros2_ws/maps/my_map
+   ```
+
+2. If permissions are an issue, fix ownership:
+
+   ```bash
+   sudo chown -R $USER:$USER ~/ros2_ws/maps
+   ```
+
+3. Make sure the directory exists **before** calling the map saver. Do not use placeholder paths like `/path_to_map/`.
+
+**Notes:**
+
+- The shared memory errors shown during map saving (e.g., `RTPS_TRANSPORT_SHM`) can be ignored — they do not affect functionality.
 
 ---
 

--- a/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
+++ b/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
@@ -1,0 +1,168 @@
+**Troubleshooting Summary for TortoiseBot on VMware Fusion & ROS2**
+
+Below is a detailed, chronological list of every issue encountered during setup and usage of TortoiseBot on macOS Monterey with VMware Fusion, Ubuntu VM, and ROS2, along with the diagnostic steps and solutions.
+
+---
+
+## 1. VMware Fusion Version Compatibility
+
+**Problem:** Installer for Fusion 13.6.2 refused to run, requiring macOS 13 Ventura.
+
+**Cause:** Fusion 13.6.x dropped support for macOS 12 Monterey.
+
+**Solution:**
+- Uninstall any 13.6.x build.
+- Download and install **VMware Fusion 13.5.2**, the final release compatible with macOS 12 Monterey.
+
+---
+
+## 2. Creating the Ubuntu 22.04 VM
+
+### 2.1 Firmware Type
+- **Select:** **UEFI** (modern standard, required by Ubuntu).
+
+### 2.2 Virtual Disk Creation
+- **Erase disk and install Ubuntu** only wipes the VM’s virtual disk—**it does not affect your Mac’s drive**.
+- **Advanced Features:** Leave at **None** (no LVM, ZFS, or encryption needed).
+
+### 2.3 ISO Mounting
+- If you see “No OS found” on boot:
+  1. Shut down the VM in Fusion.
+  2. In VM **Settings → CD/DVD**, select **Use ISO image**, choose your Ubuntu 22.04 `.iso`, and enable **Connect at power on**.
+
+---
+
+## 3. Ubuntu System Updates
+
+**Concern:** Upgrades might bump Ubuntu from 22.04 to 24.04, breaking ROS 2 Humble compatibility.
+
+**Clarification:**
+- `sudo apt update && sudo apt upgrade` only installs patches and package updates.
+- You will **only** upgrade to a new release by running `sudo do-release-upgrade` or clicking **Upgrade to Ubuntu 24.04** in Software Updater.
+- **Conclusion:** Installing updates is safe; remain on Ubuntu 22.04 for ROS 2 Humble.
+
+---
+
+## 4. Installing the Correct ROS 2 Distribution
+
+**Error:** `source /opt/ros/galactic/setup.bash` failed—no such directory on Ubuntu 22.04.
+
+**Cause:** ROS 2 Galactic targets Ubuntu 20.04, not 22.04.
+
+**Solution Options:**
+1. **Humble (recommended):** On Ubuntu 22.04, install **ROS 2 Humble Hawksbill**.
+2. **Galactic:** Create a separate Ubuntu 20.04 VM if you must use Galactic.
+
+---
+
+## 5. Workspace Setup & colcon Build
+
+### 5.1 Sourcing Setup Script
+- **Mistake:** Running `~/ros2_ws/install/setup.bash` directly (Permission denied).
+- **Fix:** Always **source** the file: `source ~/ros2_ws/install/setup.bash`.
+
+### 5.2 Missing Git
+- **Error:** `git: command not found` when cloning repos.
+- **Fix:**
+  ```bash
+  sudo apt update
+  sudo apt install git -y
+  ```
+
+### 5.3 YDLidar SDK Dependency
+- **Error:** CMake cannot find `ydlidar_sdkConfig.cmake`.
+- **Cause:** TortoiseBot includes raw SDK code but not a proper CMake package.
+- **Solution (choose one):**
+  1. **Install globally:**
+     ```bash
+     cd ~
+     git clone https://github.com/YDLIDAR/YDLidar-SDK.git
+     cd YDLidar-SDK && mkdir build && cd build
+     cmake ..
+     make && sudo make install
+     ```
+  2. **Workspace build flag:**
+     ```bash
+     colcon build --cmake-args -DCMAKE_PREFIX_PATH=$HOME/ros2_ws/install
+     ```
+
+### 5.4 Duplicate SDK Copies
+- **Error:** Duplicate package `ydlidar_sdk` in `src/tortoisebot/YDLidar-SDK` and `src/ydlidar_sdk`.
+- **Fix:** Remove the extra clone:
+  ```bash
+  rm -rf ~/ros2_ws/src/ydlidar_sdk
+  ```
+
+---
+
+## 6. Teleop & Controller Manager Issues
+
+### 6.1 Teleop Publishing Verified
+- `ros2 topic echo /cmd_vel` shows Twist messages when pressing keys—teleop is functioning.
+
+### 6.2 Missing ros2 control CLI
+- **Error:** `ros2 control list_controllers` invalid choice.
+- **Fix:**
+  ```bash
+  sudo apt install ros-humble-ros2-control ros-humble-ros2-controllers -y
+  source /opt/ros/humble/setup.bash
+  ```
+
+### 6.3 Controller Manager Service Not Available
+- **Error:** “Could not contact service /controller_manager/list_controllers”.
+- **Diagnosis Steps:**
+  1. Relaunch simulation:
+     ```bash
+     source ~/ros2_ws/install/setup.bash
+     ros2 launch tortoisebot_gazebo tortoisebot_world.launch.py
+     ```
+  2. In new shell: `ros2 node list` should list `/controller_manager`.
+  3. `ros2 control list_controllers` should show:
+     ```
+     joint_state_broadcaster [active]
+     diff_drive_controller [active]
+     ```
+
+- **If controllers missing or inactive:**
+  ```bash
+  ros2 control load_controller --set-state active diff_drive_controller
+  ```
+
+Once `controller_manager` is running and `diff_drive_controller` is active, `/cmd_vel` messages will move the robot in Gazebo.
+
+---
+
+## 7. Simulated "Wi‑Fi" Clarification
+
+- Gazebo/ROS2 uses DDS for node communication—**no real Wi‑Fi** layer simulated by default.
+- For **real robot** teleop over Wi‑Fi:
+  - Ensure PC and robot share the same LAN/Wi‑Fi.
+  - Use identical `ROS_DOMAIN_ID` and verify network connectivity via `ping`.
+
+---
+
+## 8. Stopping Robot in Gazebo
+
+- **Zero velocity cmd_vel message:**
+  ```bash
+  ros2 topic pub /cmd_vel geometry_msgs/Twist \
+    '{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}' -1
+  ```
+- **Teleop key:** Press **k** in `teleop_twist_keyboard`.
+- **Pause physics:** Click pause (||) or spacebar in Gazebo GUI.
+- **Stop simulation:** `CTRL+C` on the launch terminal.
+
+---
+
+### Best Practices & Takeaways
+
+- Always **match ROS2 distro to Ubuntu version**.
+- **Source** the correct setup file in every terminal.
+- Install **needed CLI packages** before expecting commands to exist (e.g. `ros2_control`).
+- Use ROS2 introspection (`ros2 node list`, `ros2 topic echo/info`, `ros2 control list_controllers`) to pinpoint issues.
+- Remember: VM disk erase only affects the **virtual disk**, not your host drives.
+
+---
+
+*Generated on June 28, 2025*
+

--- a/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
+++ b/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
@@ -179,34 +179,56 @@ Once `controller_manager` is running and `diff_drive_controller` is active, `/cm
 
 ---
 
-## 7. Missing Launch Files (e.g., rviz.launch.py)
+## 7. Missing Launch Files or Xacro Errors in tortoisebot\_description
+
+### 7.1 Missing `rviz.launch.py`
 
 **Error:** `file 'rviz.launch.py' was not found in the share directory of package 'tortoisebot_description'`
 
-**Cause:** Some forks of the TortoiseBot repo may not include all launch files, or the `install/` directory is outdated.
+**Cause:** The file is either missing or not installed.
 
 **Fix:**
 
-1. **Verify File Exists in Source:**
+- Launch RViz manually:
 
-   ```bash
-   ls ~/ros2_ws/src/tortoisebot/tortoisebot_description/launch/
-   ```
+  ```bash
+  rviz2 -d $(ros2 pkg prefix tortoisebot_description)/share/tortoisebot_description/rviz/tortoisebot_sensor_display.rviz
+  ```
 
-2. **If file exists but not installed, rebuild:**
+- Or create `rviz.launch.py` using a minimal template and place it in the `launch/` folder.
 
-   ```bash
-   colcon build --packages-select tortoisebot_description
-   source install/setup.bash
-   ```
+### 7.2 display.launch.py fails due to missing xacro file
 
-3. **If file does NOT exist, launch RViz manually:**
+**Error:**
 
-   ```bash
-   rviz2 -d $(ros2 pkg prefix tortoisebot_description)/share/tortoisebot_description/rviz/urdf_config.rviz
-   ```
+```
+FileNotFoundError: No such file or directory: '.../tortoisebot.xacro'
+```
 
-4. **Optional:** Create your own minimal `rviz.launch.py` to launch RViz with the robot description.
+**Cause:** `display.launch.py` expects `tortoisebot.xacro`, but only `tortoisebot_simple.xacro` or `tortoisebotreal.xacro` exists.
+
+**Fix Options:**
+
+- **Option 1 (Recommended):** Edit `display.launch.py` to point to `tortoisebot_simple.xacro`:
+
+```python
+model_file = os.path.join(pkg_share, 'models/urdf/tortoisebot_simple.xacro')
+```
+
+- **Option 2:** Create a symlink or copy:
+
+```bash
+cp ~/ros2_ws/src/tortoisebot/tortoisebot_description/models/urdf/tortoisebot_simple.xacro \
+   ~/ros2_ws/src/tortoisebot/tortoisebot_description/models/urdf/tortoisebot.xacro
+```
+
+Then rebuild:
+
+```bash
+cd ~/ros2_ws
+colcon build --packages-select tortoisebot_description
+source install/setup.bash
+```
 
 ---
 

--- a/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
+++ b/wiki_docs/5.3-ROS2_Troubleshooting_Summary.md
@@ -144,11 +144,73 @@ Below is a detailed, chronological list of every issue encountered during setup 
   ros2 control load_controller --set-state active diff_drive_controller
   ```
 
-Once `controller_manager` is running and `diff_drive_controller` is active, `/cmd_vel` messages will move the robot in Gazebo.
+Once `controller_manager` is running and `diff_drive_controller` is active, `/cmd_vel` messages will move the robot in Gazebo or on the real robot.
+
+### 6.4 Teleop Doesn’t Move Robot Despite Publishing
+
+- **Cause:** `controller_manager` is not reachable due to teleop and robot being on different networks (e.g., VM uses NAT).
+
+- **Fix:**
+
+  - Use **Bridged networking** in VMware Fusion:
+    - Go to **Virtual Machine > Settings > Network Adapter**
+    - Select **Bridged Networking (Auto-detect)**
+  - Restart the VM and verify new IP with:
+    ```bash
+    hostname -I
+    ```
+  - It should match the robot’s subnet (e.g., `192.168.1.X`).
+
+- **If bridging still shows 192.168.97.X:**
+
+  ```bash
+  sudo dhclient
+  ```
+
+  - And ensure VMware Fusion has network permissions in **macOS System Settings → Privacy & Security → Network**
+
+- **Alternative Fix:** Run teleop directly **on the robot**:
+
+  ```bash
+  ssh tortoisebot@<robot_ip>
+  source ~/ros2_ws/install/setup.bash
+  ros2 run teleop_twist_keyboard teleop_twist_keyboard
+  ```
 
 ---
 
-## 7. Simulated "Wi‑Fi" Clarification
+## 7. Missing Launch Files (e.g., rviz.launch.py)
+
+**Error:** `file 'rviz.launch.py' was not found in the share directory of package 'tortoisebot_description'`
+
+**Cause:** Some forks of the TortoiseBot repo may not include all launch files, or the `install/` directory is outdated.
+
+**Fix:**
+
+1. **Verify File Exists in Source:**
+
+   ```bash
+   ls ~/ros2_ws/src/tortoisebot/tortoisebot_description/launch/
+   ```
+
+2. **If file exists but not installed, rebuild:**
+
+   ```bash
+   colcon build --packages-select tortoisebot_description
+   source install/setup.bash
+   ```
+
+3. **If file does NOT exist, launch RViz manually:**
+
+   ```bash
+   rviz2 -d $(ros2 pkg prefix tortoisebot_description)/share/tortoisebot_description/rviz/urdf_config.rviz
+   ```
+
+4. **Optional:** Create your own minimal `rviz.launch.py` to launch RViz with the robot description.
+
+---
+
+## 8. Simulated "Wi‑Fi" Clarification
 
 - Gazebo/ROS2 uses DDS for node communication—**no real Wi‑Fi** layer simulated by default.
 - For **real robot** teleop over Wi‑Fi:
@@ -157,7 +219,7 @@ Once `controller_manager` is running and `diff_drive_controller` is active, `/cm
 
 ---
 
-## 8. Stopping Robot in Gazebo
+## 9. Stopping Robot in Gazebo
 
 - **Zero velocity cmd\_vel message:**
   ```bash
@@ -170,7 +232,7 @@ Once `controller_manager` is running and `diff_drive_controller` is active, `/cm
 
 ---
 
-## 9. Map Save Failure - Magick OpenBlob Error
+## 10. Map Save Failure - Magick OpenBlob Error
 
 **Error Message:**
 
@@ -206,12 +268,40 @@ Once `controller_manager` is running and `diff_drive_controller` is active, `/cm
 
 ---
 
+## 11. Editing Read-Only SD Card Files (e.g. netplan)
+
+**Problem:** Can't save `50-cloud-init.yaml` when editing network settings on mounted SD card.
+
+**Cause:** File system is mounted as root-owned; user lacks write permission.
+
+**Fix Option 1: Use **``** to edit**
+
+```bash
+sudo nano /media/<your_user>/writable/etc/netplan/50-cloud-init.yaml
+```
+
+**Fix Option 2: Copy → Edit → Replace**
+
+```bash
+cd /media/<your_user>/writable/etc/netplan/
+sudo cp 50-cloud-init.yaml 50-cloud-init.yaml.bak
+cp 50-cloud-init.yaml temp.yaml
+nano temp.yaml
+sudo mv temp.yaml 50-cloud-init.yaml
+```
+
+---
+
 ### Best Practices & Takeaways
 
 - Always **match ROS2 distro to Ubuntu version**.
 - **Source** the correct setup file in every terminal.
 - Install **needed CLI packages** before expecting commands to exist (e.g. `ros2_control`).
 - Use ROS2 introspection (`ros2 node list`, `ros2 topic echo/info`, `ros2 control list_controllers`) to pinpoint issues.
+- Run teleop directly on robot if DDS networking fails.
+- Ensure VM uses **Bridged networking** so it shares the same subnet as the robot.
+- Use `hostname -I` to check your VM or robot IP.
 - Remember: VM disk erase only affects the **virtual disk**, not your host drives.
 
 ---
+


### PR DESCRIPTION
- Added ROS 2 Humble (Ubuntu 22.04) setup steps with VMware Fusion on macOS
- Added macOS installation instructions 
- Added troubleshooting section covering common errors, controller setup, teleop issues, map saving, and more